### PR TITLE
아티스트 구독, 삭제 API 추가

### DIFF
--- a/Duckku_be/urls.py
+++ b/Duckku_be/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path('Login', views.Login.as_view()),
     path('Logout', views.Logout),
     path('userinfo', csrf_exempt(views.userinfo.as_view())),
-    path('artist', csrf_exempt(views.SubArtist.as_view())),
+    path('sub_artist', csrf_exempt(views.SubArtist.as_view())),
     path('my_artist_list', artist_views.my_artist_list.as_view()),
     path('my_artist_list/delete/<int:artist_id>', artist_views.delete_my),
     path('show_album_info/<int:sang_album_id>', album_views.AlbumInfo.as_view()),

--- a/Duckku_be/urls.py
+++ b/Duckku_be/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('Login', views.Login.as_view()),
     path('Logout', views.Logout),
     path('userinfo', csrf_exempt(views.userinfo.as_view())),
+    path('artist', csrf_exempt(views.SubArtist.as_view())),
     path('my_artist_list', artist_views.my_artist_list.as_view()),
     path('my_artist_list/delete/<int:artist_id>', artist_views.delete_my),
     path('show_album_info/<int:sang_album_id>', album_views.AlbumInfo.as_view()),

--- a/user/views.py
+++ b/user/views.py
@@ -123,20 +123,20 @@ class account_API(APIView):
 # 아티스트 구독, 삭제
 class SubArtist(APIView):
     def patch(self, request):
-        req_artist=get_object_or_404(Artist, artist_Name=request.artist)
+        req_artist=get_object_or_404(Artist, artist_name=request.data['artist'])
         user=request.user
 
-        user.userSubartist.add(req_artist) # pk
+        user.userSubartist_type_List.add(req_artist) # pk
         user.save()
         return Response({
             "artists" : user.userSubartist
         })
         
     def delete(self, request):
-        req_artist=get_object_or_404(Artist, artist_Name=request.artist)
+        req_artist=get_object_or_404(Artist, artist_name=request.data['artist'])
         user=request.user
         
-        user.userSubartist.remove(req_artist) # pk
+        user.userSubartist_type_List.remove(req_artist) # pk
         user.save()
 
         return Response({

--- a/user/views.py
+++ b/user/views.py
@@ -118,3 +118,27 @@ class account_API(APIView):
         user.save()
         return Response(user.user_color)
  '''
+
+
+# 아티스트 구독, 삭제
+class SubArtist(APIView):
+    def patch(self, request):
+        req_artist=get_object_or_404(Artist, artist_Name=request.artist)
+        user=request.user
+
+        user.userSubartist.add(req_artist) # pk
+        user.save()
+        return Response({
+            "artists" : user.userSubartist
+        })
+        
+    def delete(self, request):
+        req_artist=get_object_or_404(Artist, artist_Name=request.artist)
+        user=request.user
+        
+        user.userSubartist.remove(req_artist) # pk
+        user.save()
+
+        return Response({
+            "artists" : user.userSubartist
+        })


### PR DESCRIPTION
요청 받은 아티스트를 새로 구독 및 삭제하는 API를 추가하였습니다.
포스트맨을 활용해 아티스트 구독 기능의 동작을 확인하였으나, 삭제 기능은 추후 보완이 필요할 것 같습니다.