### PR TITLE
내 정보 수정(이름, 이메일, 비밀번호) 기능 추가

### DIFF
--- a/user/views.py
+++ b/user/views.py
@@ -47,11 +47,28 @@ class Login(APIView):
         else:
             return Response({"message": "유저 정보가 없음"}, status=404)
 
+# 내 정보 보기, 내 정보 수정
 class userinfo(APIView):
     def get(self, request):
         user = request.user
         data = User.objects.filter(id=user.id)
         serializer = UserSerializer(data, many=True)
+        return Response(serializer.data)
+
+    def patch(self, request):
+        user=request.user
+        data=User.objects.filter(id=user.id)
+        serializer = UserSerializer(data, many=True)
+        
+        user.userName=request.data['userName']
+        user.userEmail=request.data['userEmail']
+        if request.data["password1"] != request.data["password2"]:
+            return Response({
+                {"message": "비밀번호가 다릅니다"}
+            })
+        else:
+            user.set_password(request.data["password1"])
+        user.save()
         return Response(serializer.data)
 
 #로그아웃

--- a/user/views.py
+++ b/user/views.py
@@ -64,7 +64,7 @@ class userinfo(APIView):
         user.userEmail=request.data['userEmail']
         if request.data["password1"] != request.data["password2"]:
             return Response({
-                {"message": "비밀번호가 다릅니다"}
+                "message": "비밀번호가 다릅니다"
             })
         else:
             user.set_password(request.data["password1"])


### PR DESCRIPTION
GET method만 있던 기존의 userinfo API에 PATCH method로 내 정보 수정(이름, 이메일, 비밀번호) 기능을 추가하였으며, 동작을 확인하였습니다. Response로는 변경 사항이 반영된 user 객체를 반환합니다.


+ 내 정보 수정 전 GET method로 확인한 user 객체
<img width="1552" alt="스크린샷 2022-08-17 오전 2 55 43" src="https://user-images.githubusercontent.com/82093280/184949683-76a78de8-c677-4ec5-bb17-6c34eeb7b47e.png">

+ 내 정보 수정 후 변경된 user 객체
<img width="1552" alt="스크린샷 2022-08-17 오전 2 58 00" src="https://user-images.githubusercontent.com/82093280/184949702-2835eddb-eedd-42f3-ba3e-792450f10881.png">

+ 관리자 페이지에서 확인한 user 객체 변경 전후
<img width="500" alt="스크린샷 2022-08-17 오전 2 58 18" src="https://user-images.githubusercontent.com/82093280/184949716-0d3c2d4f-1fd5-4e38-ac67-3d61287e1d4c.png">
<img width="500" alt="스크린샷 2022-08-17 오전 2 58 57" src="https://user-images.githubusercontent.com/82093280/184949737-c48f2fba-0f47-4756-a218-af0a1bab0620.png">

+ 비밀번호 변경 시 비밀번호 확인을 거쳐야 하며, 통과하지 못할 경우 아래와 같은 message를 반환합니다.
<img width="1552" alt="스크린샷 2022-08-17 오전 3 05 52" src="https://user-images.githubusercontent.com/82093280/184949772-4b9d6dc0-8660-4ce0-8cc5-82a3ee148b7e.png">



