### PR TITLE
album_type 필드 추가 및 그에 따른 기능 수정

### DIFF
--- a/Duckku_be/urls.py
+++ b/Duckku_be/urls.py
@@ -23,7 +23,7 @@ from django.conf.urls.static import static
 from django.views.decorators.csrf import csrf_exempt
 
 urlpatterns = [
-    path('admin', admin.site.urls),
+    path('admin/', admin.site.urls),
     path('Signup', csrf_exempt(views.Signup.as_view())),
     path('Login', views.Login.as_view()),
     path('Logout', views.Logout),

--- a/album/models.py
+++ b/album/models.py
@@ -27,6 +27,7 @@ class Album(models.Model):
     price_with_ticket = models.IntegerField(null = True, default = 0)
     price_without_ticket = models.IntegerField(null = True, default = 0)
     purchased_count = models.IntegerField(null = True, default = 0)
+    album_type = models.CharField(max_length=20, null=True)
 
     def __str__(self): 
         return self.name
@@ -47,6 +48,7 @@ class AlbumFrime(models.Model):
     contains_ticket = models.BooleanField(null=True)
     #buyNumber = models.DateTimeField(auto_now_add = True, null = True)
     buyNumber = models.IntegerField(null = True, default = 0)
+    album_type = models.CharField(max_length=20, null=True)
 
     def __str__(self): 
         return self.name

--- a/album/views.py
+++ b/album/views.py
@@ -84,6 +84,7 @@ class BuyAlbum(APIView):
             newab.created_at = ab.created_at
             newab.artist = ab.artist
             newab.album_image = ab.album_image
+            newab.album_type = ab.album_type
             
             #list_store = [1,2,3,4,5,'도깨비불', '블랙맘바', 'savage']
 
@@ -127,6 +128,7 @@ class BuyAlbum(APIView):
             newab.created_at = ab.created_at
             newab.artist = ab.artist
             newab.album_image = ab.album_image
+            newab.album_type = ab.album_type
 
             # 수록곡(music_list) 카피하기
             list_store = list(ab.music_list)
@@ -144,9 +146,6 @@ class BuyAlbum(APIView):
             pcf = PhotocardFrime()  # 구매한 포토카드 생성하기
 
             # 구매한 포토카드에 상징성 포토카드에 관한 정보 넣기
-            photocards = Photocard.objects.filter(album_id = sang_album_id)
-            photocard = random.choice(photocards)
-            pcf = PhotocardFrime()
 
             pcf.album_id = photocard.album_id
             pcf.img = photocard.img


### PR DESCRIPTION
GET : http://127.0.0.1:8000/show_album_info/1

{
    "album info": {
        "id": 1,
        "name": "앨범1",
        "agency": "소속사1",
        "created_at": "2022-08-18",
        "album_image": null,
        "music_list": "노래1, 노래2, 노래3",
        "price_with_ticket": 0,
        "price_without_ticket": 0,
        "purchased_count": 2,
        "album_type": "정규1집",    <= 이거 추가됨
        "artist": 1
    },
    "musiclist": [
        "노래1",
        " 노래2",
        " 노래3"
    ]
}

+ 새로운 모델이 추가됨에 따라 앨범 구매 시, 정보를 추가하는 views.py 부분 추가함
+ 이에 따른 Response 변동 사항 API List 페이지에도 수정함
+ views.py 내 BuyAlbum 부분에서 포토카드 생성하는 코드 중 중복되는 부분 삭제함
+ url.py에서 경로를 'admin'으로만 했을 때 어드민 페이지가 나오지 않아 'admin/'으로 수정함. 제 컴에서만 발생한 오류일지도 🥲